### PR TITLE
fix:rubyのバージョンアップデート

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -318,5 +318,8 @@ DEPENDENCIES
   tzinfo-data
   web-console
 
+RUBY VERSION
+   ruby 3.2.3p157
+
 BUNDLED WITH
    2.6.2


### PR DESCRIPTION
## 概要
herokuの方でrubyのバージョンアップデートをするようなエラーが出たので実行