### PR TITLE
fix:rubocopの確認と修正

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,5 +10,5 @@ Rails.application.routes.draw do
   get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
 
   # Defines the root path route ("/")
-  root 'static_pages#start'
+  root "static_pages#start"
 end


### PR DESCRIPTION
## 概要
rubocopの確認ができていなかったので、rubocopでの確認と書式の指摘点かあったため修正。

- config/routes.rb