### PR TITLE
add:action_mailerのdefault_urlを追加

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -77,7 +77,7 @@ Rails.application.configure do
   # Disable caching for Action Mailer templates even if Action Controller
   # caching is enabled.
   config.action_mailer.perform_caching = false
-
+  config.action_mailer.default_url_options = { host: "syn-on-app-8c55e5f9481e.herokuapp.com", protocol: "https" }
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false


### PR DESCRIPTION
## 概要
ユーザー登録メールの送信時にホスト名が無いためエラーになってしまったのでaction_mailerのdefault_urlを追加した。