### PR TITLE
ユーザー登録について変更

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,4 +60,8 @@ group :test do
   gem "selenium-webdriver"
 end
 
+group :production do
+  gem "mailjet"
+end
+
 gem "devise", "~> 4.9"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -113,6 +113,12 @@ GEM
       warden (~> 1.2.3)
     drb (2.2.1)
     erubi (1.13.1)
+    faraday (2.12.2)
+      faraday-net_http (>= 2.0, < 3.5)
+      json
+      logger
+    faraday-net_http (3.4.0)
+      net-http (>= 0.5.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
     i18n (1.14.7)
@@ -147,11 +153,18 @@ GEM
       net-imap
       net-pop
       net-smtp
+    mailjet (1.8.0)
+      activesupport (>= 5.0.0)
+      faraday (~> 2.1)
+      rack (>= 1.4.0)
+      yajl-ruby
     marcel (1.0.4)
     matrix (0.4.2)
     mini_mime (1.1.5)
     minitest (5.25.4)
     msgpack (1.7.5)
+    net-http (0.6.0)
+      uri
     net-imap (0.5.5)
       date
       net-protocol
@@ -296,6 +309,7 @@ GEM
     unicode-display_width (3.1.4)
       unicode-emoji (~> 4.0, >= 4.0.4)
     unicode-emoji (4.0.4)
+    uri (1.0.2)
     useragent (0.16.11)
     warden (1.2.9)
       rack (>= 2.0.9)
@@ -311,6 +325,7 @@ GEM
     websocket-extensions (0.1.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
+    yajl-ruby (1.4.3)
     zeitwerk (2.7.1)
 
 PLATFORMS
@@ -334,6 +349,7 @@ DEPENDENCIES
   jbuilder
   jsbundling-rails
   letter_opener_web (~> 3.0)
+  mailjet
   pg (~> 1.1)
   puma (>= 5.0)
   rails (~> 7.2.2, >= 7.2.2.1)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,8 +2,8 @@ class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :validatable,
-         :confirmable, :timeoutable
+         :recoverable, :rememberable, :validatable
+         # :confirmable, :timeoutable
 
   has_many :cards, dependent: :destroy
   has_one :profile, dependent: :destroy

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -77,7 +77,9 @@ Rails.application.configure do
   # Disable caching for Action Mailer templates even if Action Controller
   # caching is enabled.
   config.action_mailer.perform_caching = false
+  # config.action_mailer.delivery_method = :mailjet_api
   config.action_mailer.default_url_options = { host: "syn-on-app-8c55e5f9481e.herokuapp.com", protocol: "https" }
+
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false

--- a/config/initializers/mailjet.rb
+++ b/config/initializers/mailjet.rb
@@ -1,0 +1,5 @@
+# Mailjet.configure do |config|
+  # config.api_key = ENV['MAILJET_API_KEY']
+  # config.secret_key = ENV['MAILJET_SECRET_KEY']
+  # config.default_from = 'my_registered_mailjet_email@domain.com'
+# end


### PR DESCRIPTION
## 概要
- mailjetのgemを追加
- ユーザー登録のメール認証を一旦取りやめ

## 内容
- メール認証のためにmailjetを使えるようにmailjetのgemを追加
- メール認証を導入するにあたりドメインの変更など、話が大きくなってしまったので、MVP後に導入することに変更
- メール認証をMVP後にするためUserモデルの内容を一部修正
