### PR TITLE
add:メールでのユーザー認証追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,22 @@ gem "tzinfo-data", platforms: %i[ windows jruby ]
 # Reduces boot times through caching; required in config/boot.rb
 gem "bootsnap", require: false
 
+# 環境変数を.envからENVにロード
+gem 'dotenv', groups: [:development, :test]
+
+# User認証系
+gem "devise", "~> 4.9"
+
+# i18n
+gem "rails-i18n", "~> 7.0.0"
+
+# mail
+gem "mailjet"
+
+# mailにcss参照
+gem "premailer-rails"
+gem "nokogiri"
+
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 # gem "image_processing", "~> 1.2"
 
@@ -67,10 +83,6 @@ group :test do
 end
 
 group :production do
-  gem "mailjet"
+ 
 end
 
-# User認証系
-gem "devise", "~> 4.9"
-# i18n
-gem "rails-i18n", "~> 7.0.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -99,6 +99,8 @@ GEM
     concurrent-ruby (1.3.5)
     connection_pool (2.5.0)
     crass (1.0.6)
+    css_parser (1.21.1)
+      addressable
     cssbundling-rails (1.4.1)
       railties (>= 6.0.0)
     date (3.4.1)
@@ -112,6 +114,7 @@ GEM
       responders
       warden (~> 1.2.3)
     diff-lcs (1.6.0)
+    dotenv (3.1.7)
     drb (2.2.1)
     erubi (1.13.1)
     factory_bot (6.5.1)
@@ -129,6 +132,7 @@ GEM
       net-http (>= 0.5.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
+    htmlentities (4.3.4)
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
     io-console (0.8.0)
@@ -205,6 +209,14 @@ GEM
       ast (~> 2.4.1)
       racc
     pg (1.5.9)
+    premailer (1.27.0)
+      addressable
+      css_parser (>= 1.19.0)
+      htmlentities (>= 4.0.0)
+    premailer-rails (1.12.0)
+      actionmailer (>= 3)
+      net-smtp
+      premailer (~> 1.7, >= 1.7.9)
     psych (5.2.3)
       date
       stringio
@@ -378,13 +390,16 @@ DEPENDENCIES
   cssbundling-rails
   debug
   devise (~> 4.9)
+  dotenv
   factory_bot_rails
   faker
   jbuilder
   jsbundling-rails
   letter_opener_web (~> 3.0)
   mailjet
+  nokogiri
   pg (~> 1.1)
+  premailer-rails
   puma (>= 5.0)
   rails (~> 7.2.2, >= 7.2.2.1)
   rails-i18n (~> 7.0.0)

--- a/app/assets/stylesheets/_card.scss
+++ b/app/assets/stylesheets/_card.scss
@@ -13,7 +13,7 @@
 
 .card-title {
   display: inline-block;
-  @include font.zen-kaku-gothic-new-regular(400)
+  @include font.submain-noto-sans-jp(400)
 }
 
 .nickname {

--- a/app/assets/stylesheets/_devise.scss
+++ b/app/assets/stylesheets/_devise.scss
@@ -4,7 +4,7 @@
 
 .field {
   color: palette.$basicfont;
-  @include font.zen-kaku-gothic-new-regular(400);
+  @include font.submain-noto-sans-jp(400);
   padding: 1%;
 }
 

--- a/app/assets/stylesheets/_font.scss
+++ b/app/assets/stylesheets/_font.scss
@@ -1,11 +1,20 @@
 
-@mixin main_font_inconsolata($weight, $width) {
+@mixin main-font-inconsolata($weight, $width) {
   font-family: "Inconsolata", serif;
   font-optical-sizing: auto;
   font-weight: $weight;
   font-style: normal;
   font-variation-settings:
     "wdth" $width;
+}
+
+// $weight: Use a value from 100 to 900
+
+@mixin submain-noto-sans-jp($weight) {
+  font-family: "Noto Sans JP", sans-serif;
+  font-optical-sizing: auto;
+  font-weight: $weight;
+  font-style: normal;
 }
 
 @mixin zen-kaku-gothic-new-regular($weight) {
@@ -19,3 +28,4 @@
   font-weight: $weight;
   font-style: normal;
 }
+

--- a/app/assets/stylesheets/_footer.scss
+++ b/app/assets/stylesheets/_footer.scss
@@ -13,7 +13,7 @@
 
 .footer_title {
   text-align: center;
-  @include font.main_font_inconsolata(200,200);
+  @include font.main-font-inconsolata(200,200);
   color: palette.$accentcolor_white;
   font-size: 15px;
 }

--- a/app/assets/stylesheets/_header.scss
+++ b/app/assets/stylesheets/_header.scss
@@ -12,7 +12,7 @@
 }
 
 .main_title {
-  @include font.main_font_inconsolata(900,200);
+  @include font.main-font-inconsolata(900,200);
   color: palette.$accentcolor_green;
   font-size: 50px;
 }

--- a/app/assets/stylesheets/_main.scss
+++ b/app/assets/stylesheets/_main.scss
@@ -9,7 +9,7 @@
   margin: 0%;
   color: palette.$accentcolor_white;
   background-color: palette.$accentcolor_green;
-  @include font.zen-kaku-gothic-new-regular(400);
+  @include font.submain-noto-sans-jp(400);
   border-radius: 0px;
 }
 
@@ -20,7 +20,7 @@
   margin: 0%;
   color: palette.$accentcolor_white;
   background-color: palette.$accentcolor_red;
-  @include font.zen-kaku-gothic-new-regular(400);
+  @include font.submain-noto-sans-jp(400);
   border-radius: 0px;
 }
 
@@ -30,7 +30,7 @@
   margin: 2%;
   color: palette.$accentcolor_white;
   background-color: palette.$accentcolor_red;
-  @include font.zen-kaku-gothic-new-regular(400);
+  @include font.submain-noto-sans-jp(400);
   border-radius: 5px;
 }
 
@@ -69,8 +69,12 @@
   display: block;
 }
 
+.text-center {
+  text-align: center;
+}
+
 .heading {
-  @include font.main_font_inconsolata(900,150);
+  @include font.main-font-inconsolata(900,150);
   color: palette.$accentcolor_green;
   font-size: 40px;
   text-align: center;
@@ -78,7 +82,7 @@
 
 .sub-model {
   & legend{
-  @include font.main_font_inconsolata(900,150);
+  @include font.main-font-inconsolata(900,150);
   color: palette.$accentcolor_green;
   font-size: 30px;
   text-align: center;
@@ -86,7 +90,7 @@
 
 .attention{
   font-size: large;
-  @include font.zen-kaku-gothic-new-regular(400);
+  @include font.submain-noto-sans-jp(400);
   text-align: center;
 }
 

--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -5,6 +5,7 @@
 @forward 'card';
 @forward 'devise';
 @forward 'side_menu';
+@forward 'mailer';
 
 @use 'palette';
 @use 'parts';
@@ -14,11 +15,24 @@
 
 a{
   text-decoration: none;
+  color: palette.$basicfont;
+  @include font.submain-noto-sans-jp(400);
+  transition: 0.2s;
 }
 
 p{
   color: palette.$basicfont;
-  @include font.zen-kaku-gothic-new-regular(400)
+  @include font.submain-noto-sans-jp(400)
+}
+
+.link-bar {
+  color: palette.$basicfont;
+  @include font.submain-noto-sans-jp(400);
+  transition: 0.2s;
+}
+
+.link-bar:hover {
+  color: palette.$accentcolor_green;
 }
 
 .btn-gray {

--- a/app/assets/stylesheets/mailer.scss
+++ b/app/assets/stylesheets/mailer.scss
@@ -1,0 +1,10 @@
+
+@use 'palette';
+@use 'parts';
+@use 'font';
+@use 'icon';
+
+.mark {
+  text-align: center;
+  color: #89EBE5;
+}

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,8 +2,8 @@ class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :validatable
-  # :confirmable, :timeoutable
+         :recoverable, :rememberable, :validatable,
+         :confirmable, :timeoutable
 
   has_many :cards, dependent: :destroy
   has_one :profile, dependent: :destroy

--- a/app/views/devise/confirmations/new.html.erb
+++ b/app/views/devise/confirmations/new.html.erb
@@ -1,16 +1,31 @@
-<h2>Resend confirmation instructions</h2>
+<div class='ground'>
+  <div class='cloth-desk'>
+    <div class='center'>
+      <h2 class='heading'><%= t('.title') %></h2>
+    </div>
+    <div class='center'>
+      <p><%= t('.message') %></p>
+    </div>
+    <div class='center'>
+      <%= render "devise/shared/error_messages", resource: resource %>
+    </div>
+    <div class='center'>
+      <%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f| %>
 
-<%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
+      <div class="field">
+        <%= f.label :email %><br />
+        <%= f.email_field :email, autofocus: true, autocomplete: "email", value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email), class:"text-field" %>
+      </div>
 
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email", value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email) %>
+      <div class="actions">
+        <%= f.submit t('helpers.submit.send_email'), class: 'btn-green' %>
+      </div>
+      <% end %>
+    </div>
   </div>
-
-  <div class="actions">
-    <%= f.submit "Resend confirmation instructions" %>
+  <div class='desk'>
+    <div class='center'>
+      <%= render "devise/shared/links" %>
+    </div>
   </div>
-<% end %>
-
-<%= render "devise/shared/links" %>
+</div>

--- a/app/views/devise/mailer/confirmation_instructions.html.erb
+++ b/app/views/devise/mailer/confirmation_instructions.html.erb
@@ -1,5 +1,14 @@
-<p>Welcome <%= @email %>!</p>
 
-<p>You can confirm your account email through the link below:</p>
+<div class='desk'>
+  <div class='center'>
+    <div class='text-center'>
+      <h2><%= t('.greeting', email: @email) %></h2>
 
-<p><%= link_to 'Confirm my account', confirmation_url(@resource, confirmation_token: @token) %></p>
+      <p><%= t('.message') %></p>
+    
+      <%= link_to t('.sign_in'), confirmation_url(@resource, confirmation_token: @token), class: 'btn-green' %>
+
+      <h2 class='mark'>SYN_on</h2>
+    </div>
+  </div>
+</div>

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -1,25 +1,37 @@
+<%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
+  <div class="text-center">
+    <%= link_to t('links.messages.not_receive_confirmation?'), new_confirmation_path(resource_name), class: 'link-bar' %>
+  </div>
+<% end %>
+
 <%- if controller_name != 'sessions' %>
-  <%= link_to "Log in", new_session_path(resource_name), class: 'btn-gray' %><br />
+  <div class="text-center">
+    <%= link_to "Sign in", new_session_path(resource_name), class: 'btn-gray' %>
+  </div>
 <% end %>
 
 <%- if devise_mapping.registerable? && controller_name != 'registrations' %>
-  <%= link_to "Sign up", new_registration_path(resource_name), class: 'btn-gray' %><br />
-<% end %>
+  <div class="text-center">
+    <%= link_to "Sign up", new_registration_path(resource_name), class: 'btn-gray' %>
+  </div>
+ <% end %>
 
 <!-- <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
-  <%= link_to "Forgot your password?", new_password_path(resource_name) %><br />
+  <div class="text-center">
+    <%= link_to "Forgot your password?", new_password_path(resource_name) %>
+  </div>
 <% end %> -->
 
-<%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
-  <%= link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name) %><br />
-<% end %>
-
 <%- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' %>
-  <%= link_to "Didn't receive unlock instructions?", new_unlock_path(resource_name) %><br />
+  <div class="text-center">
+    <%= link_to "Didn't receive unlock instructions?", new_unlock_path(resource_name) %>
+  </div>
 <% end %>
 
 <%- if devise_mapping.omniauthable? %>
-  <%- resource_class.omniauth_providers.each do |provider| %>
-    <%= button_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider), data: { turbo: false } %><br />
-  <% end %>
+  <div class="text-center">
+    <%- resource_class.omniauth_providers.each do |provider| %>
+      <%= button_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider), data: { turbo: false } %><br />
+    <% end %>
+  </div>
 <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -17,9 +17,7 @@
     <!-- GoogleFonts -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&icon_names=arrow_right" />
-    <link href="https://fonts.googleapis.com/css2?family=Inconsolata:wdth,wght@200,900&family=Zen+Kaku+Gothic+New&display=swap" rel="stylesheet">
-    <link href="https://fonts.googleapis.com/css2?family=Inconsolata:wdth,wght@150,900&family=Zen+Kaku+Gothic+New&family=Zen+Maru+Gothic&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Inconsolata:wdth,wght@150,900&family=Noto+Sans+JP:wght@100..900&family=Zen+Kaku+Gothic+New:wght@900&family=Zen+Maru+Gothic&display=swap" rel="stylesheet">
 
     <!-- Bootstrap -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-9ndCyUaIbzAi2FUVXJi0CjmCapSmO7SnpJef0486qhLnuZ2cdeRhO02iuK6FUUVM" crossorigin="anonymous">

--- a/app/views/layouts/mailer.html.erb
+++ b/app/views/layouts/mailer.html.erb
@@ -1,7 +1,9 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <%= stylesheet_link_tag 'application', media: 'all' %>
     <style>
       /* Email styles need to be inline */
     </style>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -77,7 +77,7 @@ Rails.application.configure do
   # Disable caching for Action Mailer templates even if Action Controller
   # caching is enabled.
   config.action_mailer.perform_caching = false
-  # config.action_mailer.delivery_method = :mailjet_api
+  config.action_mailer.delivery_method = :mailjet
   config.action_mailer.default_url_options = { host: "syn-on-app-8c55e5f9481e.herokuapp.com", protocol: "https" }
 
   # Ignore bad email addresses and do not raise email delivery errors.

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -11,3 +11,5 @@ Rails.application.config.assets.paths << Rails.root.join("node_modules/bootstrap
 # application.js, application.css, and all non-JS/CSS in the app/assets
 # folder are already added.
 # Rails.application.config.assets.precompile += %w[ admin.js admin.css ]
+
+Rails.application.config.assets.precompile += %w( mailer/common.css )

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -27,7 +27,7 @@ Devise.setup do |config|
   config.mailer_sender = "please-change-me-at-config-initializers-devise@example.com"
 
   # Configure the class responsible to send e-mails.
-  # config.mailer = 'Devise::Mailer'
+  config.mailer = 'Devise::Mailer'
 
   # Configure the parent class responsible to send e-mails.
   # config.parent_mailer = 'ActionMailer::Base'
@@ -310,4 +310,8 @@ Devise.setup do |config|
   # When set to false, does not sign a user in automatically after their password is
   # changed. Defaults to true, so a user is signed in automatically after changing a password.
   # config.sign_in_after_change_password = true
+end
+
+Rails.application.config.to_prepare do
+  Devise::Mailer.layout 'mailer'
 end

--- a/config/initializers/mailjet.rb
+++ b/config/initializers/mailjet.rb
@@ -1,5 +1,5 @@
-# Mailjet.configure do |config|
-# config.api_key = ENV['MAILJET_API_KEY']
-# config.secret_key = ENV['MAILJET_SECRET_KEY']
+Mailjet.configure do |config|
+  config.api_key = ENV['MAILJET_API_KEY']
+  config.secret_key = ENV['MAILJET_SECRET_KEY']
 # config.default_from = 'my_registered_mailjet_email@domain.com'
-# end
+end

--- a/config/initializers/premailer_rails.rb
+++ b/config/initializers/premailer_rails.rb
@@ -1,0 +1,1 @@
+Premailer::Rails.config.merge!(preserve_styles: true, remove_ids: true)

--- a/config/locales/activerecord/devise.en.yml
+++ b/config/locales/activerecord/devise.en.yml
@@ -6,6 +6,8 @@ en:
       confirmed: "Your email address has been successfully confirmed."
       send_instructions: "You will receive an email with instructions for how to confirm your email address in a few minutes."
       send_paranoid_instructions: "If your email address exists in our database, you will receive an email with instructions for how to confirm your email address in a few minutes."
+      new:
+        title: Resend confirmation instructions
     failure:
       already_authenticated: "You are already signed in."
       inactive: "Your account is not activated yet."
@@ -19,6 +21,9 @@ en:
     mailer:
       confirmation_instructions:
         subject: "Confirmation instructions"
+        greeting: "Welcome %{email} !"
+        message: "You can confirm your account email through the link below:"
+        sign_in_link: "Confirm my account"
       reset_password_instructions:
         subject: "Reset password instructions"
       unlock_instructions:
@@ -45,10 +50,15 @@ en:
       update_needs_confirmation: "You updated your account successfully, but we need to verify your new email address. Please check your email and follow the confirmation link to confirm your new email address."
       updated: "Your account has been updated successfully."
       updated_but_not_signed_in: "Your account has been updated successfully, but since your password was changed, you need to sign in again."
+      new:
+        title: Sign up
+        characters_minimum: characters or more
     sessions:
       signed_in: "Signed in successfully."
       signed_out: "Signed out successfully."
       already_signed_out: "Signed out successfully."
+      new:
+        title: Sign in
     unlocks:
       send_instructions: "You will receive an email with instructions for how to unlock your account in a few minutes."
       send_paranoid_instructions: "If your account exists, you will receive an email with instructions for how to unlock it in a few minutes."
@@ -63,3 +73,6 @@ en:
       not_saved:
         one: "1 error prohibited this %{resource} from being saved:"
         other: "%{count} errors prohibited this %{resource} from being saved:"
+  links:
+    messages:
+      not_receive_confirmation?: Didn't receive confirmation instructions?

--- a/config/locales/activerecord/devise.ja.yml
+++ b/config/locales/activerecord/devise.ja.yml
@@ -6,6 +6,9 @@ ja:
       confirmed: "メールアドレスを確認しました。"
       send_instructions: "数分以内にメールアドレス確認用のメールが届きます。"
       send_paranoid_instructions: "メールアドレスが登録されている場合、数分以内にメールアドレス確認用のメールが届きます。"
+      new:
+        title: Resend email
+        message: 下記メールアドレスにサインインに必要なリンクを送付致します。
     failure:
       already_authenticated: "あなたは既にサインインしています。"
       inactive: "あなたのアカウントはまだ有効になっていないようです。"
@@ -18,7 +21,10 @@ ja:
       unconfirmed: "この操作を続ける前にメールアドレスを確認してください。"
     mailer:
       confirmation_instructions:
-        subject: "確認手順"
+        subject: メールアドレスの登録確認完了
+        greeting: "ようこそ %{email} さん"
+        message: "以下のリンクからサインインページに進んでください。"
+        sign_in_link: "サインイン"
       reset_password_instructions:
         subject: "パスワードのリセット手順"
       unlock_instructions:
@@ -60,7 +66,7 @@ ja:
       unlocked: "アカウントロックが解除されました。引き続き使用するにはサインインが必要です。"
   errors:
     messages:
-      already_confirmed: "既に確認されています。サインインしてみてください。"
+      already_confirmed: "は既に確認されています。そのままサインインしてください。"
       confirmation_period_expired: "%{period}以内に確認する必要があります。新しいものをリクエストしてください。"
       expired: "有効期限が切れています。新しいものをリクエストしてください。"
       not_found: "見つかりません"
@@ -68,3 +74,6 @@ ja:
       not_saved:
         one: "1つのエラーによってこの%{resource}は保存出来ませんでした。"
         other: "%{count}個のエラーによってこの%{resource}は保存出来ませんでした。"
+  links:
+    messages:
+      not_receive_confirmation?: 確認メールが来ない場合はこちら

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -5,6 +5,7 @@ ja:
       submit: 保存
       update: 更新
       sign_in: サインイン
+      send_email: 送信
     edit: 編集
     delete: 削除
     label:


### PR DESCRIPTION
## 概要
ユーザー新規登録時にメールでの認証を追加
## 内容
- mailjetの登録、gemファイルにmailjet追加及び設定
- Userモデルのdeviseの設定を修正
- メールでの認証を追加したことによるview関係の修正
- メール送信時のscss適応のためgemファイルにpremailer-rails、nokogiri追加と適応