### PR TITLE
fix:メール送信設定を修正

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -78,7 +78,7 @@ Rails.application.configure do
   # caching is enabled.
   config.action_mailer.perform_caching = false
   config.action_mailer.delivery_method = :mailjet
-  config.action_mailer.default_url_options = { host: "syn-on-app-8c55e5f9481e.herokuapp.com", protocol: "https" }
+  config.action_mailer.default_url_options = { host: "syn-on.com", protocol: "https" }
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.

--- a/config/initializers/mailjet.rb
+++ b/config/initializers/mailjet.rb
@@ -1,5 +1,5 @@
 Mailjet.configure do |config|
   config.api_key = ENV["MAILJET_API_KEY"]
   config.secret_key = ENV["MAILJET_SECRET_KEY"]
-  # config.default_from = "my_registered_mailjet_email@domain.com"
+  config.default_from = "info@syn-on.com"
 end


### PR DESCRIPTION
## 概要
メール送信がうまくいっていないので下記の修正を実施
## 内容
- config/environments/production.rbのconfig.action_mailer.default_url_optionsを修正
- config/initializers/mailjet.rbのconfig.default_fromを設定
