### PR TITLE
fix:deviseのメール送信元のアドレス変更

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -24,7 +24,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = "please-change-me-at-config-initializers-devise@example.com"
+  config.mailer_sender = "info@syn-on.com"
 
   # Configure the class responsible to send e-mails.
   config.mailer = "Devise::Mailer"


### PR DESCRIPTION
## 概要
deviseのメール送信元のアドレスがデフォルトのままでMailjetに弾かれていたので、送信元を変更

## 内容
config/initializers/devise.rbのconfig.mailer_senderを設定済みのものに変更