### PR TITLE
fix:mailjet設定調整

### DIFF
--- a/config/initializers/mailjet.rb
+++ b/config/initializers/mailjet.rb
@@ -2,4 +2,6 @@ Mailjet.configure do |config|
   config.api_key = ENV["MAILJET_API_KEY"]
   config.secret_key = ENV["MAILJET_SECRET_KEY"]
   config.default_from = "info@syn-on.com"
+  config.api_version = 'v3.1'
+  config.perform_deliveries = true
 end


### PR DESCRIPTION
## 概要
メール送信がうまくいっていないのでmailjet設定調整

## 内容
config/initializers/mailjet.rb
- config.api_version = 'v3.1'
-  config.perform_deliveries = true
追加